### PR TITLE
refactor: apply SOLID to PostSearchService with role separation

### DIFF
--- a/BackEnd/.idea/misc.xml
+++ b/BackEnd/.idea/misc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="corretto-17" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="corretto-17" project-jdk-type="JavaSDK" />
 </project>

--- a/BackEnd/campusin/src/main/java/com/example/campusin/api/postsearch/PostSearchController.java
+++ b/BackEnd/campusin/src/main/java/com/example/campusin/api/postsearch/PostSearchController.java
@@ -1,12 +1,11 @@
 package com.example.campusin.api.postsearch;
 
 import com.example.campusin.application.postsearch.PostSearchService;
+import com.example.campusin.common.response.ApiResponse;
 import com.example.campusin.domain.postsearch.dto.response.PostSearchResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -17,18 +16,19 @@ public class PostSearchController {
 
     private final PostSearchService postSearchService;
 
-    @GetMapping
-    public List<PostSearchResponse> search(
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<List<PostSearchResponse>>> search(
             @RequestParam String keyword,
             @RequestParam(required = false) String lastSortValue,
-            @RequestParam(defaultValue = "10") int size) {
-
-        return postSearchService.searchPostsAfter(keyword, lastSortValue, size);
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        List<PostSearchResponse> results = postSearchService.searchWithKeysetPagination(keyword, lastSortValue, size);
+        return ResponseEntity.ok(ApiResponse.success(results));
     }
 
-    @GetMapping("/reindex-all")
-    public String reindexAll() {
+    @PostMapping("/reindex-all")
+    public ResponseEntity<ApiResponse<String>> reindexAll() {
         postSearchService.reindexAllAsync();
-        return "재색인 요청 접수 (비동기)";
+        return ResponseEntity.accepted().body(ApiResponse.success("재색인 요청이 접수되었습니다."));
     }
 }

--- a/BackEnd/campusin/src/main/java/com/example/campusin/application/postsearch/PostReindexer.java
+++ b/BackEnd/campusin/src/main/java/com/example/campusin/application/postsearch/PostReindexer.java
@@ -1,0 +1,29 @@
+package com.example.campusin.application.postsearch;
+
+
+import com.example.campusin.application.postsearch.policy.BatchReindexPolicy;
+import com.example.campusin.domain.post.Post;
+import com.example.campusin.infra.post.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class PostReindexer {
+    private final PostRepository postRepository;
+    private final PostSearchIndexer postSearchIndexer;
+    private final BatchReindexPolicy batchReindexPolicy;
+
+    public void reindexAll() {
+        Long lastId = 0L;
+        while (true) {
+            List<Post> batch = batchReindexPolicy.nextBatch(lastId);
+            if (batch.isEmpty()) break;
+
+            postSearchIndexer.bulkIndex(batch);
+            lastId = batch.get(batch.size() - 1).getId();
+        }
+    }
+}

--- a/BackEnd/campusin/src/main/java/com/example/campusin/application/postsearch/PostSearchIndexer.java
+++ b/BackEnd/campusin/src/main/java/com/example/campusin/application/postsearch/PostSearchIndexer.java
@@ -3,33 +3,31 @@ package com.example.campusin.application.postsearch;
 import com.example.campusin.domain.post.Post;
 import com.example.campusin.domain.postsearch.PostSearch;
 import com.example.campusin.domain.postsearch.PostSearchMapper;
+import com.example.campusin.infra.postsearch.PostSearchRepository;
 import lombok.RequiredArgsConstructor;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch.core.IndexRequest;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 
-@Service
+
+@Component
 @RequiredArgsConstructor
 public class PostSearchIndexer {
-
-    private final OpenSearchClient openSearchClient;
-
-    @Value("${spring.opensearch.post-index}")
-    private String postIndex;
+    private final PostSearchRepository postSearchRepository;
 
     public void index(Post post) {
-        try {
-            PostSearch postSearch = PostSearchMapper.fromPost(post);
+        PostSearch document = PostSearchMapper.fromPost(post);
+        postSearchRepository.bulkIndex(List.of(document));
+    }
 
-            openSearchClient.index(IndexRequest.of(i -> i
-                    .index(postIndex)
-                    .id(postSearch.getId())
-                    .document(postSearch)
-            ));
-        } catch (Exception e) {
-            throw new RuntimeException("OpenSearch 인덱싱 실패", e);
-        }
+    public void bulkIndex(List<Post> posts) {
+        List<PostSearch> documents = posts.stream()
+                .map(PostSearchMapper::fromPost)
+                .toList();
+        postSearchRepository.bulkIndex(documents);
     }
 }

--- a/BackEnd/campusin/src/main/java/com/example/campusin/application/postsearch/PostSearchService.java
+++ b/BackEnd/campusin/src/main/java/com/example/campusin/application/postsearch/PostSearchService.java
@@ -18,59 +18,18 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class PostSearchService {
-
     private final PostSearchRepository postSearchRepository;
-    private final PostRepository postRepository;
+    private final PostReindexer postReindexer;
 
-    public List<PostSearchResponse> searchPostsAfter(String keyword, String lastSortValue, int size) {
-        return postSearchRepository.searchByKeyset(keyword, lastSortValue, size).stream()
+    public List<PostSearchResponse> searchWithKeysetPagination(String keyword, String lastSortValue, int size) {
+        return postSearchRepository.searchByKeyset(keyword, lastSortValue, size)
+                .stream()
                 .map(PostSearchResponse::from)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Async
     public void reindexAllAsync() {
-        System.out.println("[재색인] 비동기 재색인 시작");
-
-        Long lastId = 0L;
-        int batchSize = 9000;
-        int totalIndexed = 0;
-        List<Post> batch;
-        Instant startAll = Instant.now();
-
-        try {
-            do {
-                Instant start = Instant.now();
-
-                batch = postRepository.findTop9000ByIdGreaterThanOrderByIdAsc(lastId);
-                if (batch.isEmpty()) break;
-
-                List<PostSearch> documents = batch.stream()
-                        .map(PostSearchMapper::fromPost)
-                        .collect(Collectors.toList());
-
-                postSearchRepository.bulkIndex(documents);
-
-                lastId = batch.get(batch.size() - 1).getId();
-                totalIndexed += documents.size();
-
-                Instant end = Instant.now();
-                System.out.printf("[재색인] %s ~ %s 인덱싱 완료 (소요: %d ms, 누적: %d)%n",
-                        String.valueOf(documents.get(0).getId()),
-                        String.valueOf(lastId),
-                        Duration.between(start, end).toMillis(),
-                        totalIndexed
-                );
-
-            } while (batch.size() == batchSize);
-
-            Instant endAll = Instant.now();
-            System.out.printf("[재색인] 전체 완료 - 총 인덱싱 수: %d, 총 소요 시간: %d ms%n",
-                    totalIndexed,
-                    Duration.between(startAll, endAll).toMillis());
-        } catch (Exception e) {
-            System.err.println("[재색인] 재색인 중 예외 발생: " + e.getMessage());
-            e.printStackTrace();
-        }
+        postReindexer.reindexAll();
     }
 }

--- a/BackEnd/campusin/src/main/java/com/example/campusin/application/postsearch/policy/BatchReindexPolicy.java
+++ b/BackEnd/campusin/src/main/java/com/example/campusin/application/postsearch/policy/BatchReindexPolicy.java
@@ -1,0 +1,9 @@
+package com.example.campusin.application.postsearch.policy;
+
+import com.example.campusin.domain.post.Post;
+
+import java.util.List;
+
+public interface BatchReindexPolicy {
+    List<Post> nextBatch(Long lastId);
+}

--- a/BackEnd/campusin/src/main/java/com/example/campusin/application/postsearch/policy/DefaultBatchReindexPolicy.java
+++ b/BackEnd/campusin/src/main/java/com/example/campusin/application/postsearch/policy/DefaultBatchReindexPolicy.java
@@ -1,0 +1,20 @@
+package com.example.campusin.application.postsearch.policy;
+
+import com.example.campusin.domain.post.Post;
+import com.example.campusin.infra.post.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class DefaultBatchReindexPolicy implements BatchReindexPolicy {
+    private static final int BATCH_SIZE = 9000;
+    private final PostRepository postRepository;
+
+    @Override
+    public List<Post> nextBatch(Long lastId) {
+        return postRepository.findTop9000ByIdGreaterThanOrderByIdAsc(lastId);
+    }
+}

--- a/BackEnd/campusin/src/main/java/com/example/campusin/common/response/ApiResponse.java
+++ b/BackEnd/campusin/src/main/java/com/example/campusin/common/response/ApiResponse.java
@@ -35,6 +35,12 @@ public class ApiResponse<T> {
         return new ApiResponse(new ApiResponseHeader(SUCCESS, SUCCESS_MESSAGE), map);
     }
 
+    public static <T> ApiResponse<T> success(T body) {
+        Map<String, T> map = new HashMap<>();
+        map.put("data", body);
+        return new ApiResponse<>(new ApiResponseHeader(SUCCESS, SUCCESS_MESSAGE), map);
+    }
+
     public static <T> ApiResponse<T> fail() {
         return new ApiResponse(new ApiResponseHeader(FAILED, FAILED_MESSAGE), null);
     }


### PR DESCRIPTION
- 분리된 책임에 따라 PostReindexer 도입
- BatchReindexPolicy 전략 패턴 도입 및 위치 리팩토링
- PostSearchService에서 인덱싱/검색 책임 분리