### PR TITLE
refactor: MessageRoom 멱등성/동시성 처리 구조 개선

### DIFF
--- a/BackEnd/campusin/src/main/java/com/example/campusin/CampusinApplication.java
+++ b/BackEnd/campusin/src/main/java/com/example/campusin/CampusinApplication.java
@@ -7,8 +7,10 @@ package com.example.campusin;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing // https://europani.github.io/spring/2021/10/05/027-baseTimeEntity.html
+@EnableScheduling
 @SpringBootApplication
 public class CampusinApplication {
     public static void main(String[] args) {

--- a/BackEnd/campusin/src/main/java/com/example/campusin/application/message/MessageRoomService.java
+++ b/BackEnd/campusin/src/main/java/com/example/campusin/application/message/MessageRoomService.java
@@ -7,6 +7,7 @@ import com.example.campusin.application.post.exception.PostNotFoundException;
 import com.example.campusin.application.user.exception.UserNotFoundException;
 import com.example.campusin.domain.message.Message;
 import com.example.campusin.domain.message.MessageRoom;
+import com.example.campusin.domain.message.MessageRoomIdempotency;
 import com.example.campusin.domain.message.VisibilityState;
 import com.example.campusin.domain.message.dto.MessageRoomsWithLastMessages;
 import com.example.campusin.domain.message.dto.request.MessageRoomCreateRequest;
@@ -16,6 +17,7 @@ import com.example.campusin.domain.message.dto.response.MessageRoomListResponse;
 import com.example.campusin.domain.message.dto.response.MessageRoomResponse;
 import com.example.campusin.domain.user.User;
 import com.example.campusin.infra.message.MessageRepository;
+import com.example.campusin.infra.message.MessageRoomIdempotencyRepository;
 import com.example.campusin.infra.message.MessageRoomRepository;
 import com.example.campusin.infra.post.PostRepository;
 import com.example.campusin.infra.user.UserRepository;
@@ -37,11 +39,11 @@ public class MessageRoomService {
     private final MessageRoomRepository messageRoomRepository;
     private final MessageRepository messageRepository;
     private final MessageRoomTxService messageRoomTxService;
+    private final MessageRoomIdempotencyRepository messageRoomIdempotencyRepository;
     private final UserRepository userRepository;
     private final PostRepository postRepository;
 
     // 쪽지방 생성
-    @Transactional
     public MessageRoomIdResponse saveMessageRoom(Long userId, MessageRoomCreateRequest request, String idempotencyKey) {
         Long senderId = userId;
         Long receiverId = request.getReceiverId();
@@ -49,6 +51,13 @@ public class MessageRoomService {
 
         if (senderId.equals(receiverId)) {
             throw new InvalidRequestStateException("INVALID MESSAGE TARGET");
+        }
+
+        // 멱등키 선행 조회 — 락 없이 즉시 기존 응답 반환
+        Optional<MessageRoomIdempotency> preCheck = messageRoomIdempotencyRepository
+                .findBySenderIdAndReceiverIdAndIdempotencyKey(senderId, receiverId, idempotencyKey);
+        if (preCheck.isPresent()) {
+            return new MessageRoomIdResponse(preCheck.get().getMessageRoomId());
         }
 
         Long small = Math.min(senderId, receiverId);

--- a/BackEnd/campusin/src/main/java/com/example/campusin/application/message/MessageRoomTxService.java
+++ b/BackEnd/campusin/src/main/java/com/example/campusin/application/message/MessageRoomTxService.java
@@ -33,6 +33,8 @@ public class MessageRoomTxService {
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public MessageRoomIdResponse saveUnderLock(Long senderId, Long receiverId, Long postId, MessageRoomCreateRequest request, String idempotencyKey) {
+        // 바깥에서 선행 조회를 통과한 요청이 락 대기 후 진입했을 때,
+        // 이미 다른 요청이 생성을 완료했는지 재확인 — 경쟁 진입 방어
         Optional<MessageRoomIdempotency> existing = messageRoomIdempotencyRepository
                 .findBySenderIdAndReceiverIdAndIdempotencyKey(senderId, receiverId, idempotencyKey);
 

--- a/BackEnd/campusin/src/main/java/com/example/campusin/application/message/scheduler/IdempotencyCleanupScheduler.java
+++ b/BackEnd/campusin/src/main/java/com/example/campusin/application/message/scheduler/IdempotencyCleanupScheduler.java
@@ -1,0 +1,35 @@
+package com.example.campusin.application.message.scheduler;
+
+import com.example.campusin.infra.message.MessageRoomIdempotencyRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class IdempotencyCleanupScheduler {
+
+    private static final int BATCH_SIZE = 1000;
+    private static final long RETENTION_HOURS = 24L;
+
+    private final MessageRoomIdempotencyRepository messageRoomIdempotencyRepository;
+
+    @Scheduled(cron = "0 0 2-6 * * *")
+    @Transactional
+    public void cleanupExpired() {
+        LocalDateTime cutoff = LocalDateTime.now().minusHours(RETENTION_HOURS);
+        int total = 0;
+        int deleted;
+        do {
+            deleted = messageRoomIdempotencyRepository.deleteExpired(cutoff, BATCH_SIZE);
+            total += deleted;
+        } while (deleted > 0);
+
+        log.info("[IdempotencyCleanupScheduler] expired rows deleted: total={}, cutoff={}", total, cutoff);
+    }
+}

--- a/BackEnd/campusin/src/main/java/com/example/campusin/infra/message/MessageRoomIdempotencyRepository.java
+++ b/BackEnd/campusin/src/main/java/com/example/campusin/infra/message/MessageRoomIdempotencyRepository.java
@@ -2,9 +2,19 @@ package com.example.campusin.infra.message;
 
 import com.example.campusin.domain.message.MessageRoomIdempotency;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface MessageRoomIdempotencyRepository extends JpaRepository<MessageRoomIdempotency, Long> {
     Optional<MessageRoomIdempotency> findBySenderIdAndReceiverIdAndIdempotencyKey(Long senderId, Long receiverId, String idempotencyKey);
+
+    @Modifying
+    @Query(value = "DELETE FROM message_room_idempotency WHERE created_at < :cutoff LIMIT :batchSize",
+            nativeQuery = true)
+    int deleteExpired(@Param("cutoff") LocalDateTime cutoff,
+                      @Param("batchSize") int batchSize);
 }

--- a/BackEnd/campusin/src/test/java/com/example/campusin/application/message/MessageRoomServiceTest.java
+++ b/BackEnd/campusin/src/test/java/com/example/campusin/application/message/MessageRoomServiceTest.java
@@ -7,6 +7,7 @@ import com.example.campusin.application.post.exception.PostNotFoundException;
 import com.example.campusin.application.user.exception.UserNotFoundException;
 import com.example.campusin.domain.message.Message;
 import com.example.campusin.domain.message.MessageRoom;
+import com.example.campusin.domain.message.MessageRoomIdempotency;
 import com.example.campusin.domain.message.VisibilityState;
 import com.example.campusin.domain.message.dto.MessageRoomsWithLastMessages;
 import com.example.campusin.domain.message.dto.request.MessageRoomCreateRequest;
@@ -19,6 +20,7 @@ import com.example.campusin.domain.board.BoardType;
 import com.example.campusin.domain.post.Post;
 import com.example.campusin.domain.user.User;
 import com.example.campusin.infra.message.MessageRepository;
+import com.example.campusin.infra.message.MessageRoomIdempotencyRepository;
 import com.example.campusin.infra.message.MessageRoomRepository;
 import com.example.campusin.infra.post.PostRepository;
 import com.example.campusin.infra.user.UserRepository;
@@ -46,6 +48,8 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
@@ -64,6 +68,8 @@ class MessageRoomServiceTest {
     MessageRepository messageRepository;
     @Mock
     MessageRoomTxService messageRoomTxService;
+    @Mock
+    MessageRoomIdempotencyRepository messageRoomIdempotencyRepository;
     @Mock
     UserRepository userRepository;
     @Mock
@@ -141,6 +147,33 @@ class MessageRoomServiceTest {
                 assertThatThrownBy(() -> messageRoomService.saveMessageRoom(userId, request, "k"))
                         .isInstanceOf(IllegalStateException.class);
                 verify(messageRoomRepository).releaseLock(lockName);
+            }
+        }
+
+        @Nested
+        @DisplayName("동일 멱등키로 이미 처리된 요청이면")
+        class Context_when_idempotent_hit {
+
+            @Test
+            @DisplayName("락을 획득하지 않고 기존 메시지방 ID를 반환한다")
+            void 락_없이_기존_ID를_반환한다() {
+                // given
+                Long userId = 1L;
+                MessageRoomCreateRequest request = new MessageRoomCreateRequest(3L, 2L, "first");
+                String idempotencyKey = "dup-key";
+                MessageRoomIdempotency existing = new MessageRoomIdempotency(userId, 2L, idempotencyKey, 77L);
+
+                when(messageRoomIdempotencyRepository
+                        .findBySenderIdAndReceiverIdAndIdempotencyKey(userId, 2L, idempotencyKey))
+                        .thenReturn(Optional.of(existing));
+
+                // when
+                MessageRoomIdResponse response = messageRoomService.saveMessageRoom(userId, request, idempotencyKey);
+
+                // then
+                assertThat(response.getMessageRoomId()).isEqualTo(77L);
+                verify(messageRoomRepository, never()).acquireLock(anyString(), anyInt());
+                verifyNoInteractions(messageRoomTxService);
             }
         }
 

--- a/BackEnd/campusin/src/test/java/com/example/campusin/application/message/scheduler/IdempotencyCleanupSchedulerTest.java
+++ b/BackEnd/campusin/src/test/java/com/example/campusin/application/message/scheduler/IdempotencyCleanupSchedulerTest.java
@@ -1,0 +1,89 @@
+package com.example.campusin.application.message.scheduler;
+
+import com.example.campusin.infra.message.MessageRoomIdempotencyRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("IdempotencyCleanupScheduler")
+class IdempotencyCleanupSchedulerTest {
+
+    @Mock
+    MessageRoomIdempotencyRepository messageRoomIdempotencyRepository;
+
+    @InjectMocks
+    IdempotencyCleanupScheduler scheduler;
+
+    @Nested
+    @DisplayName("cleanupExpired 메서드는")
+    class Describe_cleanupExpired {
+
+        @Test
+        @DisplayName("24시간 이전 cutoff와 배치 사이즈 1000으로 저장소를 호출한다")
+        void cutoff는_24시간_전이고_배치사이즈는_1000이다() {
+            // given
+            LocalDateTime before = LocalDateTime.now().minusHours(24);
+            when(messageRoomIdempotencyRepository.deleteExpired(any(LocalDateTime.class), eq(1000)))
+                    .thenReturn(0);
+
+            // when
+            scheduler.cleanupExpired();
+
+            // then
+            ArgumentCaptor<LocalDateTime> cutoffCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+            verify(messageRoomIdempotencyRepository).deleteExpired(cutoffCaptor.capture(), eq(1000));
+
+            LocalDateTime cutoff = cutoffCaptor.getValue();
+            long diffSeconds = Math.abs(ChronoUnit.SECONDS.between(cutoff, before));
+            assertThat(diffSeconds).isLessThan(5);
+        }
+
+        @Test
+        @DisplayName("삭제가 0이 될 때까지 루프를 돈다")
+        void 루프를_돈다() {
+            // given — 2000건을 두 번의 배치로 삭제 후 종료
+            when(messageRoomIdempotencyRepository.deleteExpired(any(LocalDateTime.class), eq(1000)))
+                    .thenReturn(1000)
+                    .thenReturn(1000)
+                    .thenReturn(0);
+
+            // when
+            scheduler.cleanupExpired();
+
+            // then
+            verify(messageRoomIdempotencyRepository, times(3))
+                    .deleteExpired(any(LocalDateTime.class), eq(1000));
+        }
+
+        @Test
+        @DisplayName("첫 호출부터 0이면 한 번만 호출한다")
+        void 삭제할_것이_없으면_한_번만_호출한다() {
+            // given
+            when(messageRoomIdempotencyRepository.deleteExpired(any(LocalDateTime.class), eq(1000)))
+                    .thenReturn(0);
+
+            // when
+            scheduler.cleanupExpired();
+
+            // then
+            verify(messageRoomIdempotencyRepository, times(1))
+                    .deleteExpired(any(LocalDateTime.class), eq(1000));
+        }
+    }
+}


### PR DESCRIPTION
### 변경 배경
- Named Lock 내부에서 수행하던 멱등키 조회를 락 외부로 이동
- 락과 멱등성의 역할을 개념적으로 분리
- 멱등키 테이블의 무한 증가를 방지하기 위한 cleanup 스케줄러 추가

### 변경 내용
- MessageRoomService: 락 획득 전 멱등키 선행 조회 → 히트 시 락 경쟁 없이 즉시 기존 응답
- MessageRoomTxService: 락 내부 재조회 유지 
- IdempotencyCleanupScheduler 신규: 새벽 2-6시 매시 정각, 24h 이전 row 1000건 배치 삭제 루프
- MessageRoomIdempotencyRepository.deleteExpired 네이티브 쿼리 추가
- CampusinApplication에 @EnableScheduling 추가

### 관련 이슈
Closes #613